### PR TITLE
Changed input prompt for SPICE base directory to remove ambiguity

### DIFF
--- a/autometa/make_Metakernel.py
+++ b/autometa/make_Metakernel.py
@@ -325,7 +325,7 @@ def make_Metakernel(spacecraft, basedir = '', force_update=False):
 
 if __name__ == "__main__":
     spacecraft = input('Name of target spacecraft:')
-    basedir = input('Name of the SPICE base directory (press enter for current directory):')
+    basedir = input('Path to directory containing the SPICE base directory (press enter for current directory):')
     result = make_Metakernel(spacecraft, basedir = basedir)
     print('Finished!')
     print('SPICE MetaKernel for {} wrtten to: {}'.format(spacecraft, result))


### PR DESCRIPTION
**Issue:**
Script prompts for user to input their SPICE base directory, and then creates a SPICE/ directory within. If the user already has a SPICE/ directory (i.e. created previously for a different spacecraft), pointing to _this_ directory will result in the creation of:

SPICE/
 | - generic/
 | - spacecraft_a/
 | - SPICE/
 | | - generic/
 | | - spacecraft_b/

Which is the unintended behaviour.

**Fix:**
Instead, I prompt the user to point to the directory containing their SPICE base directory. i.e. SPICE/..
