### PR TITLE
Fix urllib import error

### DIFF
--- a/autometa/make_Metakernel.py
+++ b/autometa/make_Metakernel.py
@@ -226,7 +226,7 @@ def run_wgetForSPICE(url, savedir, namepattern, show_progress=True, force_update
     subprocess.run(commandline, check=True)
 
 def run_urllibForSPICE(url, savedir, namepattern, show_progress=True, force_update=False):
-    import urllib
+    import urllib.request
     import re
     from fnmatch import fnmatch
     import tqdm
@@ -251,8 +251,6 @@ def run_urllibForSPICE(url, savedir, namepattern, show_progress=True, force_upda
     matching_file_list = [l for l in file_list if fnmatch(l, namepattern)]
         
     # Now download
-    import urllib.request
-    
     for f in tqdm.tqdm(matching_file_list, desc='Downloading to {}'.format(savedir)):
         if not savedir.is_dir():
             savedir.mkdir(parents=True)


### PR DESCRIPTION
Wrong urllib import lead to:
```
AttributeError: module 'urllib' has no attribute 'request'
```
in `run_urllibForSPICE` function in `make_Metakernel.py`.
Fixed the import and removed the duplicate one